### PR TITLE
Add translation assignment helper

### DIFF
--- a/modules/profileadv/controllers/front/ProfileadvFrontController.php
+++ b/modules/profileadv/controllers/front/ProfileadvFrontController.php
@@ -42,6 +42,31 @@ class ProfileadvFrontController extends ModuleFrontController
         }
     }
 
+    /**
+     * Assign translation lists to Smarty.
+     *
+     * @param array  $translations
+     * @param string $moduleName
+     */
+    protected function assignTranslations(array $translations, string $moduleName)
+    {
+        $cookie = Context::getContext()->cookie;
+        $iso_code = isset($cookie->id_lang) ? Language::getIsoById((int) $cookie->id_lang) : 'es';
+
+        $this->context->smarty->assign([
+            $moduleName . 'dogbreedlist'          => $translations['breed']['dog'][$iso_code],
+            $moduleName . 'catbreedlist'          => $translations['breed']['cat'][$iso_code],
+            $moduleName . 'typelist'              => $translations['type'][$iso_code],
+            $moduleName . 'genrelist'             => $translations['genre'][$iso_code],
+            $moduleName . 'esterilizedlist'       => $translations['esterilized'][$iso_code],
+            $moduleName . 'activitylist'          => $translations['activity'][$iso_code],
+            $moduleName . 'physicalconditionlist' => $translations['physical-condition'][$iso_code],
+            $moduleName . 'feedinglist'           => $translations['feeding'][$iso_code],
+            $moduleName . 'pathologieslist'       => $translations['pathologies'][$iso_code],
+            $moduleName . 'allergieslist'         => $translations['allergies'][$iso_code],
+        ]);
+    }
+
     public function setMedia()
     {
         $module_name = 'profileadv';

--- a/modules/profileadv/controllers/front/addfirstpet.php
+++ b/modules/profileadv/controllers/front/addfirstpet.php
@@ -139,31 +139,10 @@ class ProfileadvAddFirstpetModuleFrontController extends ProfileadvFrontControll
             $this->context->smarty->assign($name_module . 'product_list', $product_list);
         } else {
 
-            $iso_code =  isset($cookie->id_lang) ? Language::getIsoById((int)$cookie->id_lang) : 'es';
-
-            $dogBreedList = $this->translationList['breed']['dog'][$iso_code];
-            $catBreedList = $this->translationList['breed']['cat'][$iso_code];
-            $genreList = $this->translationList['genre'][$iso_code];
-            $typeList = $this->translationList['type'][$iso_code];
-            $esterilizedList = $this->translationList['esterilized'][$iso_code];
-            $activityList = $this->translationList['activity'][$iso_code];
-            $physicalConditionList = $this->translationList['physical-condition'][$iso_code];
-            $feedingList = $this->translationList['feeding'][$iso_code];
-            $pathologiesList = $this->translationList['pathologies'][$iso_code];
-            $allergiesList = $this->translationList['allergies'][$iso_code];
             $currentDate = date('Y-m-d');
             $maxOldDate = date("Y-m-d", strtotime("-25 year"));
 
-            $this->context->smarty->assign($name_module . 'dogbreedlist', $dogBreedList);
-            $this->context->smarty->assign($name_module . 'catbreedlist', $catBreedList);
-            $this->context->smarty->assign($name_module . 'typelist', $typeList);
-            $this->context->smarty->assign($name_module . 'genrelist', $genreList);
-            $this->context->smarty->assign($name_module . 'esterilizedlist', $esterilizedList);
-            $this->context->smarty->assign($name_module . 'activitylist', $activityList);
-            $this->context->smarty->assign($name_module . 'physicalconditionlist', $physicalConditionList);
-            $this->context->smarty->assign($name_module . 'feedinglist', $feedingList);
-            $this->context->smarty->assign($name_module . 'pathologieslist', $pathologiesList);
-            $this->context->smarty->assign($name_module . 'allergieslist', $allergiesList);
+            $this->assignTranslations($this->translationList, $name_module);
             $this->context->smarty->assign($name_module . 'currentdate', $currentDate);
             $this->context->smarty->assign($name_module . 'maxolddate', $maxOldDate);
 

--- a/modules/profileadv/controllers/front/addpet.php
+++ b/modules/profileadv/controllers/front/addpet.php
@@ -140,18 +140,6 @@ class ProfileadvAddpetModuleFrontController extends ProfileadvFrontController
             $this->context->smarty->assign($name_module . 'product_list', $product_list);
         } else {
 
-            $iso_code =  isset($cookie->id_lang) ? Language::getIsoById((int)$cookie->id_lang) : 'es';
-
-            $dogBreedList = $this->translationList['breed']['dog'][$iso_code];
-            $catBreedList = $this->translationList['breed']['cat'][$iso_code];
-            $genreList = $this->translationList['genre'][$iso_code];
-            $typeList = $this->translationList['type'][$iso_code];
-            $esterilizedList = $this->translationList['esterilized'][$iso_code];
-            $activityList = $this->translationList['activity'][$iso_code];
-            $physicalConditionList = $this->translationList['physical-condition'][$iso_code];
-            $feedingList = $this->translationList['feeding'][$iso_code];
-            $pathologiesList = $this->translationList['pathologies'][$iso_code];
-            $allergiesList = $this->translationList['allergies'][$iso_code];
             $currentDate = date('Y-m-d');
             $maxOldDate = date("Y-m-d", strtotime("-25 year"));
 
@@ -164,16 +152,7 @@ class ProfileadvAddpetModuleFrontController extends ProfileadvFrontController
                 $currentCustomerPets[] = $value['name']; //Only get names
             }
 
-            $this->context->smarty->assign($name_module . 'dogbreedlist', $dogBreedList);
-            $this->context->smarty->assign($name_module . 'catbreedlist', $catBreedList);
-            $this->context->smarty->assign($name_module . 'typelist', $typeList);
-            $this->context->smarty->assign($name_module . 'genrelist', $genreList);
-            $this->context->smarty->assign($name_module . 'esterilizedlist', $esterilizedList);
-            $this->context->smarty->assign($name_module . 'activitylist', $activityList);
-            $this->context->smarty->assign($name_module . 'physicalconditionlist', $physicalConditionList);
-            $this->context->smarty->assign($name_module . 'feedinglist', $feedingList);
-            $this->context->smarty->assign($name_module . 'pathologieslist', $pathologiesList);
-            $this->context->smarty->assign($name_module . 'allergieslist', $allergiesList);
+            $this->assignTranslations($this->translationList, $name_module);
             $this->context->smarty->assign($name_module . 'currentdate', $currentDate);
             $this->context->smarty->assign($name_module . 'maxolddate', $maxOldDate);
             $this->context->smarty->assign($name_module . 'currentcustomerpets', $currentCustomerPets);

--- a/modules/profileadv/controllers/front/editpet.php
+++ b/modules/profileadv/controllers/front/editpet.php
@@ -99,31 +99,11 @@ class ProfileadvEditpetModuleFrontController extends ProfileadvFrontController
 
         $this->context->smarty->assign($name_module . 'editpetdata', $petData);
 
-        $iso_code =  isset($cookie->id_lang) ? Language::getIsoById((int)$cookie->id_lang) : 'es';
-
-        $dogBreedList = $this->translationList['breed']['dog'][$iso_code];
-        $catBreedList = $this->translationList['breed']['cat'][$iso_code];
-        $genreList = $this->translationList['genre'][$iso_code];
-        $typeList = $this->translationList['type'][$iso_code];
-        $esterilizedList = $this->translationList['esterilized'][$iso_code];
-        $activityList = $this->translationList['activity'][$iso_code];
-        $physicalConditionList = $this->translationList['physical-condition'][$iso_code];
-        $feedingList = $this->translationList['feeding'][$iso_code];
-        $pathologiesList = $this->translationList['pathologies'][$iso_code];
-        $allergiesList = $this->translationList['allergies'][$iso_code];
         $currentDate = date('Y-m-d');
         $maxOldDate = date("Y-m-d", strtotime("-25 year"));
 
-        $this->context->smarty->assign($name_module . 'dogbreedlist', $dogBreedList);
-        $this->context->smarty->assign($name_module . 'catbreedlist', $catBreedList);
-        $this->context->smarty->assign($name_module . 'typelist', $typeList);
-        $this->context->smarty->assign($name_module . 'genrelist', $genreList);
-        $this->context->smarty->assign($name_module . 'esterilizedlist', $esterilizedList);
-        $this->context->smarty->assign($name_module . 'activitylist', $activityList);
-        $this->context->smarty->assign($name_module . 'physicalconditionlist', $physicalConditionList);
-        $this->context->smarty->assign($name_module . 'feedinglist', $feedingList);
-        $this->context->smarty->assign($name_module . 'pathologieslist', $pathologiesList);
-        $this->context->smarty->assign($name_module . 'allergieslist', $allergiesList);
+        $this->assignTranslations($this->translationList, $name_module);
+
         $this->context->smarty->assign($name_module . 'currentdate', $currentDate);
         $this->context->smarty->assign($name_module . 'maxolddate', $maxOldDate);
 


### PR DESCRIPTION
## Summary
- add a helper in `ProfileadvFrontController` to assign translation arrays to Smarty
- use the helper in addfirstpet, addpet and editpet controllers

## Testing
- `php -l modules/profileadv/controllers/front/ProfileadvFrontController.php`
- `php -l modules/profileadv/controllers/front/addfirstpet.php`
- `php -l modules/profileadv/controllers/front/addpet.php`
- `php -l modules/profileadv/controllers/front/editpet.php`


------
https://chatgpt.com/codex/tasks/task_e_686be6dccdcc8320998780a0f2f2d555