### PR TITLE
Fix addpet initialization and product recommendation sizing

### DIFF
--- a/modules/profileadv/controllers/front/addfirstpet.php
+++ b/modules/profileadv/controllers/front/addfirstpet.php
@@ -1,7 +1,7 @@
 <?php
 require_once _PS_MODULE_DIR_.'profileadv/controllers/front/addpet.php';
 
-class ProfileadvAddFirstpetModuleFrontController extends AddPetController
+class ProfileadvAddFirstpetModuleFrontController extends ProfileadvAddpetModuleFrontController
 {
     public function init()
     {

--- a/modules/profileadv/controllers/front/addpet.php
+++ b/modules/profileadv/controllers/front/addpet.php
@@ -5,9 +5,8 @@ include_once(_PS_MODULE_DIR_ . 'profileadv/classes/profileadvanced.class.php');
 include_once(_PS_MODULE_DIR_ . 'profileadv/classes/AgeCalculator.php');
 include_once(_PS_MODULE_DIR_ . 'profileadv/profileadv.php');
 
-use PrestaShop\PrestaShop\Adapter\Tools;
 
-class AddPetController extends ProfileadvFrontController
+class ProfileadvAddpetModuleFrontController extends ProfileadvFrontController
 {
     public $ssl = true;
     public $auth;

--- a/modules/profileadv/controllers/front/ajaxprofileadv.php
+++ b/modules/profileadv/controllers/front/ajaxprofileadv.php
@@ -390,7 +390,7 @@ class ProfileadvAjaxprofileadvModuleFrontController extends ModuleFrontControlle
 
         switch ((int)$data['type']) {
             case 1:
-                switch ($data['desired_weight']) {
+                switch (true) {
                     case ($data['desired_weight'] < 5):
                         $size = 1;
                         break;
@@ -406,10 +406,16 @@ class ProfileadvAjaxprofileadvModuleFrontController extends ModuleFrontControlle
                     case ($data['desired_weight'] > 50):
                         $size = 5;
                         break;
+                    default:
+                        $size = 1;
+                        break;
                 }
                 break;
             case 2:
                 $size = 1; //Cats by default
+                break;
+            default:
+                $size = 1;
                 break;
         }
 


### PR DESCRIPTION
## Summary
- remove incorrect namespaced Tools import in addpet controller
- ensure desired weight ranges use `switch (true)` and have defaults in ajax controller

## Testing
- `php -l modules/profileadv/controllers/front/addpet.php`
- `php -l modules/profileadv/controllers/front/ajaxprofileadv.php`

------
https://chatgpt.com/codex/tasks/task_e_6876d8941c0083209fdc2c1577cbe9e8