### PR TITLE
Fix warnings when $logged not set

### DIFF
--- a/modules/profileadv/views/templates/front/addpet.tpl
+++ b/modules/profileadv/views/templates/front/addpet.tpl
@@ -847,7 +847,7 @@
                             </div>
                             <div class="navigation-buttons">
                                 <button type="button" class="btn previous" data-step='6'>{l s='Previous' mod='profileadv'}</button>
-                                {if $logged}
+                                {if isset($logged) && $logged}
                                     <button type="submit" class="btn btn-submit" id="submit-button" onClick="submitClicked()">{l s='Finalizar' mod='profileadv'}</button>
                                 {else}
                                     <button type="button" class="btn next" data-step='8'>{l s='Next' mod='profileadv'}</button>
@@ -855,7 +855,7 @@
                             </div>
                         </section>
 
-                        {if !$logged}
+                        {if !isset($logged) || !$logged}
                         <!-- Email step for guests -->
                         <section data-step='8' class="data-step" style="display: none;">
                             <div class="profileadv-add-header">


### PR DESCRIPTION
## Summary
- avoid warnings when $logged isn't defined in addpet.tpl

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687955f729748320807527c5af75785b